### PR TITLE
Temp fix for 'warning: URI.escape is obsolete'

### DIFF
--- a/lib/wine_shipping/api_client.rb
+++ b/lib/wine_shipping/api_client.rb
@@ -266,7 +266,7 @@ module WineShipping
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode(@config.base_url + path)
+      URI::Parser.new.escape(@config.base_url + path)
     end
 
     # Builds the HTTP request body

--- a/lib/wine_shipping/configuration.rb
+++ b/lib/wine_shipping/configuration.rb
@@ -175,7 +175,7 @@ module WineShipping
 
     def base_url
       url = "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
-      URI.encode(url)
+      URI::Parser.new.escape(url)
     end
 
     # Gets API key (with prefix if set).


### PR DESCRIPTION
Just removing the warning for now to avoid collateral effects but we should be back on this in the future to apply a better solution for each case.

**Example:**

```ruby
2.7.6 (penrose)[10] » URI.encode('https://apidock.com/ruby/v2_5_5/URI/encode_www_form/class/téstã')
(pry):10: warning: URI.escape is obsolete
=> "https://apidock.com/ruby/v2_5_5/URI/encode_www_form/class/t%C3%A9st%C3%A3"

2.7.6 (penrose)[11] » URI::Parser.new.escape('https://apidock.com/ruby/v2_5_5/URI/encode_www_form/class/téstã')
=> "https://apidock.com/ruby/v2_5_5/URI/encode_www_form/class/t%C3%A9st%C3%A3"
```

**References:**
https://stackoverflow.com/questions/65423458/ruby-2-7-says-uri-escape-is-obsolete-what-replaces-it
https://stackoverflow.com/questions/34274838/why-is-uri-escape-marked-as-obsolete-and-where-is-this-regexpunsafe-constant